### PR TITLE
Configure Travis to wait longer to accomodate bundling sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
 script:
 - . .ros_ci/add_tag.sh
-- .ros_ci/ce_build.sh
+- travis_wait 100 .ros_ci/ce_build.sh
 before_deploy:
 - . .ros_ci/before_deploy.sh
 deploy:


### PR DESCRIPTION
*Issue #, if available:*
N//A

*Description of changes:*
We are bundling sources now when we run colcon bundle and this takes up more time. 
This changes extends the travis wait time to accommodate for including sources. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
