### PR TITLE
Remove setup-file element from .rosinstall

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,2 +1,1 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
+

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,1 +1,1 @@
-- git: {local-name: src/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}
+- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,3 +1,1 @@
-# kinetic.rosinstall
-- setup-file: {local-name: /opt/ros/kinetic/setup.sh}
 - git: {local-name: src/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}


### PR DESCRIPTION
Not needed and will just confuse customers as we also support Melodic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
