### PR TITLE
Remove version defaults in roboMakerSettings.json

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -42,7 +42,7 @@
           "sourceBundleFile": "./HelloWorld/robot_ws/bundle/output.tar",
           "architecture": "X86_64",
           "robotSoftwareSuite": {
-            "version": "Kinetic",
+            "version": "<capitalised name of ROS distribution, e.g. Kinetic>",
             "name": "ROS"
           },
           "launchConfig": {
@@ -60,12 +60,12 @@
             "launchFile": "empty_world.launch"
           },
           "robotSoftwareSuite": {
-            "version": "Kinetic",
+            "version": "<capitalised name of ROS distribution, e.g. Kinetic>",
             "name": "ROS"
           },
           "simulationSoftwareSuite": {
             "name": "Gazebo",
-            "version": "7"
+            "version": "<gazebo version number, e.g. 7>"
           },
           "renderingEngine": {
             "name": "OGRE",


### PR DESCRIPTION
Prepopulating the json with specific versions (like Kinetic, Gazebo7) could lead to customer confusion, e.g. if they choose to use a Melodic dev environment in C9. This change removes those defaults. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
