### PR TITLE
Update .rosinstall and use the TURTLEBOT3_MODEL env var gracefully.

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,6 +1,3 @@
 # Amazon ROS HelloWorld package dependencies
 - git: {local-name: src/deps/turtlebot3, uri: 'https://github.com/ROBOTIS-GIT/turtlebot3.git', version: ros2}
-- git: {local-name: src/deps/turtlebot3_msgs, uri: 'https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git', version: ros2}
 - git: {local-name: src/deps/cartographer/cartographer_ros, uri: 'https://github.com/ROBOTIS-GIT/cartographer_ros.git', version: dashing}
-- git: {local-name: src/deps/DynamixelSDK, uri: 'https://github.com/ROBOTIS-GIT/DynamixelSDK.git', version: ros2}
-- git: {local-name: src/deps/hls_lfcd_lds_driver, uri: 'https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git', version: ros2}

--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,7 +1,4 @@
 - git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: ros2}
 - git: {local-name: src/deps/xacro, uri: "https://github.com/AAlon/xacro", version: ros2-find}
 - git: {local-name: src/deps/turtlebot3, uri: 'https://github.com/ROBOTIS-GIT/turtlebot3.git', version: ros2}
-- git: {local-name: src/deps/turtlebot3_msgs, uri: 'https://github.com/ROBOTIS-GIT/turtlebot3_msgs.git', version: ros2}
 - git: {local-name: src/deps/cartographer/cartographer_ros, uri: 'https://github.com/ROBOTIS-GIT/cartographer_ros.git', version: dashing}
-- git: {local-name: src/deps/DynamixelSDK, uri: 'https://github.com/ROBOTIS-GIT/DynamixelSDK.git', version: ros2}
-- git: {local-name: src/deps/hls_lfcd_lds_driver, uri: 'https://github.com/ROBOTIS-GIT/hls_lfcd_lds_driver.git', version: ros2}

--- a/simulation_ws/src/hello_world_simulation/launch/empty_world.launch.py
+++ b/simulation_ws/src/hello_world_simulation/launch/empty_world.launch.py
@@ -25,8 +25,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.actions import ExecuteProcess
 from launch.substitutions import LaunchConfiguration
 
-TURTLEBOT3_MODEL = os.environ['TURTLEBOT3_MODEL']
-
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='True')

--- a/simulation_ws/src/turtlebot3_description_reduced_mesh/launch/spawn_turtlebot.launch.py
+++ b/simulation_ws/src/turtlebot3_description_reduced_mesh/launch/spawn_turtlebot.launch.py
@@ -37,7 +37,8 @@ def generate_launch_description():
         default_value='true',
         description='Use sim time',
         )
-    turtlebot3_model = 'waffle_pi'
+
+    turtlebot3_model = os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')
     turtlebot3_location = get_package_share_directory('turtlebot3_description_reduced_mesh') \
         + '/urdf/turtlebot3_' + turtlebot3_model + '.urdf.xacro'
     with subprocess.Popen(['ros2', 'run', 'xacro', 'xacro', turtlebot3_location], stdout=subprocess.PIPE) as proc:


### PR DESCRIPTION
This change will remove released packages from .rosinstall and update the TB model to properly load it from the environment like we do in ROS1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
