### PR TITLE
Set gazebo model path for ROS2

### DIFF
--- a/simulation_ws/src/hello_world_simulation/launch/empty_world.launch.py
+++ b/simulation_ws/src/hello_world_simulation/launch/empty_world.launch.py
@@ -28,6 +28,7 @@ from launch.substitutions import LaunchConfiguration
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='True')
+    env = {'GAZEBO_MODEL_PATH': os.path.split(get_package_share_directory('turtlebot3_description_reduced_mesh'))[0]}
     empty_world_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             get_package_share_directory('gazebo_ros') + '/launch/empty_world.launch.py'))
@@ -44,6 +45,7 @@ def generate_launch_description():
             output='screen'),
         ExecuteProcess(
             cmd=['gzserver', '--verbose', '-s', 'libgazebo_ros_factory.so'],
+            additional_env=env,
             output='screen'
         ),
         IncludeLaunchDescription(


### PR DESCRIPTION
Without this change it's required to manually set the GAZEBO_MODEL_PATH.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
