### PR TITLE
Launch gazebo using gazebo_ros' launch files and set the model/media paths correctly

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,4 +1,1 @@
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: ros2}
 - git: {local-name: src/deps/xacro, uri: "https://github.com/AAlon/xacro", version: ros2-find}
-- git: {local-name: src/deps/turtlebot3, uri: 'https://github.com/ROBOTIS-GIT/turtlebot3.git', version: ros2}
-- git: {local-name: src/deps/cartographer/cartographer_ros, uri: 'https://github.com/ROBOTIS-GIT/cartographer_ros.git', version: dashing}

--- a/simulation_ws/src/hello_world_simulation/package.xml
+++ b/simulation_ws/src/hello_world_simulation/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>hello_world_simulation</name>
-  <version>1.2.0</version>
+  <version>2.0.0</version>
   <description>
     AWS RoboMaker simulation package with a TurtleBot3 in an empty Gazebo world.
   </description>
@@ -16,7 +16,9 @@
   <depend>turtlebot3_simulations</depend>
   <depend>xacro</depend>
   <exec_depend>gazebo</exec_depend>
+  <exec_depend>turtlebot3_bringup</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_media_path="${prefix}/worlds"/>
   </export>
 </package>

--- a/simulation_ws/src/turtlebot3_description_reduced_mesh/package.xml
+++ b/simulation_ws/src/turtlebot3_description_reduced_mesh/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>turtlebot3_description_reduced_mesh</name>
-  <version>1.1.0</version>
+  <version>2.0.0</version>
   <description>
     A copy of the TurtleBot3 models with reduced poly counts. Based off turtlebot3_description package.
   </description>
@@ -14,5 +14,6 @@
   <exec_depend>gazebo</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_model_path="${prefix}/.."/>
   </export>
 </package>


### PR DESCRIPTION
Instead of tweaking the environment variables to include the models we should leverage the path plugin like we did in ROS1. This follows a pattern similar to https://github.com/chapulina/dolly/blob/master/dolly_gazebo/launch/dolly.launch.py and will help us integrate it with RoboMaker.

Verified the TB gets spawned by running:
`ros2 launch hello_world_simulation empty_world.launch.py gui:=true`
Without the need to set anything else (except for TURTLEBOT3_MODEL).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
