### PR TITLE
Add deploy stage to avoid deployment race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ deploy:
     upload-dir: travis/${SA_NAME}/${ROS_DISTRO}/gazebo${GAZEBO_VERSION}
 jobs:
   include:
+    - stage: Build & Bundle
     - stage: Deploy
       script: ". .ros_ci/add_tag.sh"
       env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ notifications:
     - ros-contributions@amazon.com
     - travis-build@platform-notifications.robomaker.aws.a2z.com
 env:
-  matrix:
-  - ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9 WORKSPACES="robot_ws"
-  - ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9 WORKSPACES="simulation_ws"
   global:
   - SA_NAME=hello-world
   - SA_PACKAGE_NAME=hello_world_robot
@@ -49,7 +46,9 @@ deploy:
 jobs:
   include:
     - stage: Build & Bundle
+      env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9 WORKSPACES="robot_ws"
     - stage: Build & Bundle
+      env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9 WORKSPACES="simulation_ws"
     - stage: Deploy
       script: ". .ros_ci/add_tag.sh"
       env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,15 @@ deploy:
     on:
       branch: ros2
     upload-dir: travis/${SA_NAME}/${ROS_DISTRO}/gazebo${GAZEBO_VERSION}
-  - provider: script
-    script: bash .ros_ci/codepipeline_deploy.sh
-    on:
-      branch: ros2
+jobs:
+  include:
+    - stage: Deploy
+      script: ". .ros_ci/add_tag.sh"
+      env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9
+      deploy:
+        - provider: script
+          script: bash .ros_ci/codepipeline_deploy.sh
+          on:
+            branch: ros2
 after_deploy:
 - .ros_ci/post_deploy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ deploy:
 jobs:
   include:
     - stage: Build & Bundle
+    - stage: Build & Bundle
     - stage: Deploy
       script: ". .ros_ci/add_tag.sh"
       env: ROS_DISTRO=dashing ROS_VERSION=2 GAZEBO_VERSION=9


### PR DESCRIPTION
Splitting the deployment stage will be safer as we'll be able to add as many build flavors we want (e.g. eloquent distro, log-based sim workspace etc.) without risking deployment conflict/race conditions.

See https://docs.travis-ci.com/user/build-stages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
