### PR TITLE
Update ros launch command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Launch the application with the following commands:
 - *Running Simulation Application*
     ```bash
     source simulation_ws/install/local_setup.sh
-    roslaunch hello_world_simulation empty_world.launch.py
+    ros2 launch hello_world_simulation empty_world.launch.py
     ```
 
 ## Using this sample with RoboMaker


### PR DESCRIPTION
Should be `ros2 launch` not `roslaunch` for ROS2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
