### PR TITLE
Adding missing env variable to roboMakerSettings

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -57,7 +57,10 @@
           "architecture": "X86_64",
           "launchConfig": {
             "packageName": "hello_world_simulation",
-            "launchFile": "empty_world.launch.py"
+            "launchFile": "empty_world.launch.py",
+            "environmentVariables": {
+              "TURTLEBOT3_MODEL": "waffle_pi"
+            }
           },
           "robotSoftwareSuite": {
             "version": "<capitalised name of ROS distribution, e.g. Dashing>",


### PR DESCRIPTION
RoboMakerSettings was missing TURTLEBOT3_MODEL environment variable.
Simulation jobs will fail to launch without this environment variable being set.

*Issue #, if available:*
N/A

*Description of changes:*
Changes to roboMakerSettings.json to include environment variables. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
