### PR TITLE
Remove turtlebot3 packages from .rosinstall

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,1 +1,0 @@
-- git: {local-name: src/deps/turtlebot3_simulations, uri: "https://github.com/ROBOTIS-GIT/turtlebot3_simulations", version: 1.2.0}

--- a/simulation_ws/src/hello_world_simulation/package.xml
+++ b/simulation_ws/src/hello_world_simulation/package.xml
@@ -12,6 +12,5 @@
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
   <depend>turtlebot3_description</depend>
-  <depend>turtlebot3_gazebo</depend>
   <exec_depend>gazebo</exec_depend>
 </package>

--- a/simulation_ws/src/hello_world_simulation/package.xml
+++ b/simulation_ws/src/hello_world_simulation/package.xml
@@ -13,6 +13,5 @@
   <depend>gazebo_plugins</depend>
   <depend>turtlebot3_description</depend>
   <depend>turtlebot3_gazebo</depend>
-  <depend>turtlebot3_simulations</depend>
   <exec_depend>gazebo</exec_depend>
 </package>


### PR DESCRIPTION
*Description of changes:*

In the same vein as https://github.com/aws-robotics/aws-robomaker-sample-application-cloudwatch/pull/67 and https://github.com/aws-robotics/aws-robomaker-sample-application-persondetection/pull/66, this removes `turtlebot3` packages from the `.rosinstall` file, so that these packages are no longer obtained by source code through `rosws update`, but rather directly by binary through `rosdep install`, which should be the preferred method.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
