### PR TITLE
Add turtlebot3_description in robot workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/build
+**/log
+**/install
+**/bundle
+**/deps

--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,1 +1,1 @@
-
+- git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros1"}

--- a/robot_ws/src/hello_world_robot/CMakeLists.txt
+++ b/robot_ws/src/hello_world_robot/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   geometry_msgs
   nav_msgs
+  turtlebot3_description # required to install .rviz model
 )
 
 ################################################################################
@@ -65,6 +66,11 @@ install(DIRECTORY deploymentScripts
   DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}
 )
 
+# Copy the rviz model for easier access in AWS RoboMaker RViz 
+install(FILES ${turtlebot3_description_DIR}/../rviz/model.rviz
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rviz
+  RENAME turtlebot3_model.rviz
+)
 ################################################################################
 # Test
 ################################################################################

--- a/robot_ws/src/hello_world_robot/launch/rotate.launch
+++ b/robot_ws/src/hello_world_robot/launch/rotate.launch
@@ -13,7 +13,7 @@
 
   <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
   <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description_reduced_mesh)/urdf/turtlebot3_$(arg model).urdf.xacro" />
 
 
   <!-- Rotate the robot on launch -->

--- a/robot_ws/src/hello_world_robot/launch/rotate.launch
+++ b/robot_ws/src/hello_world_robot/launch/rotate.launch
@@ -11,6 +11,11 @@
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
+  <!-- Optional environment variable, default is "waffle_pi". Note that "burger" does not have a camera -->
+  <arg name="model" default="$(optenv TURTLEBOT3_MODEL waffle_pi)" doc="model type [burger, waffle, waffle_pi]"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+
+
   <!-- Rotate the robot on launch -->
   <node pkg="hello_world_robot" type="rotate" name="rotate" output="screen"/>
 </launch>

--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -19,6 +19,7 @@
   <depend>visualization_msgs</depend>
   <depend>actionlib_msgs</depend>
   <depend>turtlebot3_msgs</depend>
+  <depend>turtlebot3_description</depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -20,6 +20,7 @@
   <depend>actionlib_msgs</depend>
   <depend>turtlebot3_msgs</depend>
   <depend>turtlebot3_description</depend>
+  <depend>turtlebot3_description_reduced_mesh</depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>


### PR DESCRIPTION
*Issue #, if available:*
Currently, robot model is not visible in rviz because the parameter robot_description hasn't been created.
 
*Description of changes:*
This PR adds turtlebot3_description as a dependency in robot workspace, and create the parameter robot_description correctly in rotate.launch

Tested both locally and on AWS Robomaker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
