### PR TITLE
Add turtlebot3-description-reduced-mesh and robot_state_publisher as dependencies

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,1 +1,1 @@
-
+- git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros2"}

--- a/robot_ws/src/hello_world_robot/launch/rotate.launch.py
+++ b/robot_ws/src/hello_world_robot/launch/rotate.launch.py
@@ -27,9 +27,15 @@ import launch_ros.actions
 
 import lifecycle_msgs.msg
 
+from ament_index_python.packages import get_package_share_directory
+ 
+TURTLEBOT3_MODEL = os.environ.get('TURTLEBOT3_MODEL', 'waffle_pi')
 
 def generate_launch_description():
     """Main."""
+    turtlebot_urdf_file_name = 'turtlebot3_' + TURTLEBOT3_MODEL + '.urdf'
+    turtlebot_urdf_file_path = os.path.join(get_package_share_directory('turtlebot3_description_reduced_mesh'), 'urdf', turtlebot_urdf_file_name)
+
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             'use_sim_time',
@@ -37,7 +43,18 @@ def generate_launch_description():
             description='Use sim time if true. Default: true'),
         launch_ros.actions.Node(
             package='hello_world_robot', node_executable='rotate', output='screen',
-            name='rotate')
+            name='rotate'),
+        launch_ros.actions.Node(
+            package='robot_state_publisher',
+            node_executable='robot_state_publisher',
+            node_name='robot_state_publisher',
+            output='screen',
+            parameters=[{
+                'use_sim_time': launch.substitutions.LaunchConfiguration('use_sim_time')
+            }],
+            arguments=[
+                turtlebot_urdf_file_path
+            ])
     ])
     return ld 
 

--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclpy</depend>
   <depend>geometry_msgs</depend>
+  <depend>robot_state_publisher</depend>
   <exec_depend>turtlebot3_bringup</exec_depend>
   <test_depend>python3-pytest</test_depend>
   <export>


### PR DESCRIPTION
* Add turtlebot3-description-reduced-mesh in .rosinstall for robot model reference. It enables robot model to be successfully loaded in rviz.
* Add robot_state_publisher for publishing robot description and TF.

Tested locally and on AWS RoboMaker via bundles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
