### PR TITLE
Update README.md for vcs import in ros2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ rosdep update
 
 ```bash
 cd robot_ws
-rosws update
+vcs import < .rosinstall
 rosdep install --from-paths src --ignore-src -r -y
 colcon build
 ```
@@ -34,7 +34,7 @@ colcon build
 
 ```bash
 cd simulation_ws
-rosws update
+vcs import < .rosinstall
 rosdep install --from-paths src --ignore-src -r -y
 colcon build
 ```


### PR DESCRIPTION
Replace `rosws update` with `vcs import < .rosinstall` as `rosws update` is deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
