### PR TITLE
Bumping package versions to 2.2.0 accounting for Travis -> GH migration

### DIFF
--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>hello_world_robot</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>
     AWS RoboMaker robot package with a rotating Turtlebot3
   </description>

--- a/simulation_ws/src/hello_world_simulation/package.xml
+++ b/simulation_ws/src/hello_world_simulation/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>hello_world_simulation</name>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <description>
     AWS RoboMaker simulation package with a TurtleBot3 in an empty Gazebo world.
   </description>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumping ROS2 package versions to account for Travis -> GH actions transition

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
