### PR TITLE
Update gh action schedule and bump GH actions version to 2.3.2

### DIFF
--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -43,7 +43,7 @@ jobs:
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -51,7 +51,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -65,7 +65,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' &&  !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
     - id: deploy_bundle
       name: Deploy bundle to S3
-      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.3.2
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS1 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -78,7 +78,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
     - name: Update App-manifest version number
       id: update-app-manifest
-      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.3.2
       env:
         AWS_CODECOMMIT_REPO_NAME: '${{ secrets.AWS_CODECOMMIT_REPO_NAME_PREFIX_HELLO_WORLD }}-${{ matrix.distro }}-gazebo${{ matrix.gazebo }}'
         AWS_CODECOMMIT_BRANCH_NAME: ${{ secrets.AWS_CODECOMMIT_BRANCH_NAME_HELLO_WORLD }}

--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - ros1
   schedule:
-    - cron: '0 14 * * *'  # run at 2 pm UTC/ 7 am PST everyday
-
+    - cron: '0 2,14 * * *'  # runs at 2am & 2pm UTC i.e. 7pm & 7am PST everyday
+    
 jobs:
   build_and_bundle_ros1:
     strategy:

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -36,7 +36,7 @@ jobs:
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -44,7 +44,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.3.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -58,7 +58,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
     - id: deploy_bundle
       name: Deploy bundle to S3
-      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.3.2
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS2 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -71,7 +71,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && !contains(steps.robot_ws_build.outcome, 'failure') && !contains(steps.simulation_ws_build.outcome, 'failure') }}
     - name: Update App-manifest version number
       id: update-app-manifest
-      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.3.1
+      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.3.2
       env:
         AWS_CODECOMMIT_REPO_NAME: '${{ secrets.AWS_CODECOMMIT_REPO_NAME_PREFIX_HELLO_WORLD }}-${{ matrix.distro }}-gazebo${{ matrix.gazebo }}'
         AWS_CODECOMMIT_BRANCH_NAME: ${{ secrets.AWS_CODECOMMIT_BRANCH_NAME_HELLO_WORLD }}
@@ -120,4 +120,4 @@ jobs:
           ]
         namespace: SimulationWorkspaceBuild
         metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'failure') }}
-eneccccrienjcgckgbbkcrhhfrndrcbhvgiegnfbijbd
+

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - ros2
   schedule:
-    - cron: '0 14 * * *'  # run at 2 pm UTC/ 7 am PST everyday
+    - cron: '0 2,14 * * *'  # run at 2am & 2pm UTC i.e. 7pm & 7am PST everyday
 
 jobs:
   build_and_bundle_ros2:
@@ -120,3 +120,4 @@ jobs:
           ]
         namespace: SimulationWorkspaceBuild
         metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'failure') }}
+eneccccrienjcgckgbbkcrhhfrndrcbhvgiegnfbijbd


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Change GH action schedule to every 12 hours from previous 24 hour interval.
- Bump robomaker GH actions version to 2.3.2 (accounting for https://github.com/aws-robotics/aws-robomaker-github-actions/pull/12)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
