### PR TITLE
pull in the timeout fix for gazebo_ros package's spawn_entity.py script

### DIFF
--- a/simulation_ws/.rosinstall
+++ b/simulation_ws/.rosinstall
@@ -1,1 +1,2 @@
 - git: {local-name: src/deps/turtlebot3-description-reduced-mesh, uri: "https://github.com/aws-robotics/turtlebot3-description-reduced-mesh.git", version: "ros2"}
+- git: {local-name: src/deps/gazebo-ros-pkgs, uri: "https://github.com/ros-simulation/gazebo_ros_pkgs.git", version: "c071749932a541a5b8aced23c3414724a8cd1949"}


### PR DESCRIPTION
### Description of changes

This pull request is for pulling in the fix at [ros-simulation/gazebo_ros_pkgs#1140](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1140), which increases the default timeout of the SpawnEntityNode's client. If the timeout is hit, then this sample app will encounter a situation where the Turtlebot will never spawn in the world.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.