### PR TITLE
Bump aws-actions/configure-aws-credentials to 1.5.4

### DIFF
--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -59,7 +59,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1.5.2
+      uses: aws-actions/configure-aws-credentials@v1.5.4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS1 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS1 }}
@@ -100,7 +100,7 @@ jobs:
     if: ${{ always() && github.event_name != 'pull_request' }}
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1.5.2
+      uses: aws-actions/configure-aws-credentials@v1.5.4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS1 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS1 }}

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -52,7 +52,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1.5.2
+      uses: aws-actions/configure-aws-credentials@v1.5.4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}
@@ -95,7 +95,7 @@ jobs:
     if: ${{ always() && github.event_name != 'pull_request' }}
     steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1.5.2
+      uses: aws-actions/configure-aws-credentials@v1.5.4
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}


### PR DESCRIPTION
The `set-env` command is disabled (reference: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

aws-actions/configure-aws-credentials@1.5.4 contains a fix for the issue. Bumping up the version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
