### PR TITLE
Fix logic for determining pass/fail of workspace build (ROS2)

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -68,9 +68,9 @@ jobs:
       uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
         namespace: RobotWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'failure') }}
+        metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'success') }}
     - name: Log Simulation Workspace Build Status
       uses: ros-tooling/action-cloudwatch-metrics@0.0.4
       with:
         namespace: SimulationWorkspaceBuild
-        metric-value: ${{ ! contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'failure') }}
+        metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'success') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+**/build
+**/log
+**/install
+**/bundle
+**/deps


### PR DESCRIPTION
*Description of changes:*

We're currently incorrectly reporting `skipped` and `cancelled` workspace builds as successful.

This pull request updates the logic for reporting pass vs fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
