### PR TITLE
Add colcon bundle retries

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   ament_lint:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-rolling-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-focal-ros-rolling-ros-base-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   ament_lint:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-eloquent-ros-base-latest
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-rolling-ros-base-latest
     strategy:
       fail-fast: false
       matrix:
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ros-tooling/action-ros-lint@v0.1
         with:
+          distribution: rolling
           linter: ${{ matrix.linter }}
           package-name: |
             hello_world_simulation

--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -51,6 +51,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: robot_ws
         generate-sources: true
+        colcon-bundle-retries: 3
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
       uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
@@ -58,6 +59,7 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
+        colcon-bundle-retries: 3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1.5.4
       with:

--- a/.github/workflows/ros1.yml
+++ b/.github/workflows/ros1.yml
@@ -42,10 +42,10 @@ jobs:
         # TODO(ros-tooling/setup-ros-docker#7): calling chown is necessary for now
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - name: Scan using git-secrets
-      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.2
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -53,7 +53,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -67,7 +67,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - id: upload_bundle
       name: Upload bundle to S3
-      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.2
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS1 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -80,7 +80,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - name: Update App-manifest version number
       id: update-app-manifest
-      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.2
       env:
         AWS_CODECOMMIT_REPO_NAME: '${{ secrets.AWS_CODECOMMIT_REPO_NAME_PREFIX_HELLO_WORLD }}-${{ matrix.distro }}-gazebo${{ matrix.gazebo }}'
         AWS_CODECOMMIT_BRANCH_NAME: ${{ secrets.AWS_CODECOMMIT_BRANCH_NAME_HELLO_WORLD }}

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -44,6 +44,7 @@ jobs:
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: robot_ws
         generate-sources: true
+        colcon-bundle-retries: 3
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
       uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
@@ -51,6 +52,7 @@ jobs:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
         workspace-dir: simulation_ws
+        colcon-bundle-retries: 3
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1.5.4
       with:

--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -35,10 +35,10 @@ jobs:
         # TODO(ros-tooling/setup-ros-docker#7): calling chown is necessary for now
         sudo chown -R rosbuild:rosbuild "$HOME" .
     - name: Scan using git-secrets
-      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@2.4.2
     - id: robot_ws_build
       name: Build and Bundle Robot Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -46,7 +46,7 @@ jobs:
         generate-sources: true
     - id: simulation_ws_build
       name: Build and Bundle Simulation Workspace
-      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/robomaker-sample-app-ci@2.4.2
       with:
         ros-distro: ${{ matrix.distro }}
         gazebo-version: ${{ matrix.gazebo }}
@@ -60,7 +60,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - id: upload_bundle
       name: Upload bundle to S3
-      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/s3-cp-action@2.4.2
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_ROS2 }}
         AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -73,7 +73,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }}
     - name: Update App-manifest version number
       id: update-app-manifest
-      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.1
+      uses: aws-robotics/aws-robomaker-github-actions/codecommit-put-file-action@2.4.2
       env:
         AWS_CODECOMMIT_REPO_NAME: '${{ secrets.AWS_CODECOMMIT_REPO_NAME_PREFIX_HELLO_WORLD }}-${{ matrix.distro }}-gazebo${{ matrix.gazebo }}'
         AWS_CODECOMMIT_BRANCH_NAME: ${{ secrets.AWS_CODECOMMIT_BRANCH_NAME_HELLO_WORLD }}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add colcon bundle retries and bump robomaker gh action versions as a part of the change.

Blocked by - https://github.com/aws-robotics/aws-robomaker-github-actions/pull/22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
