### PR TITLE
Bump version due to new canonical python patch

### DIFF
--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>hello_world_robot</name>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <description>
     AWS RoboMaker robot package with a rotating Turtlebot3
   </description>

--- a/robot_ws/src/hello_world_robot/setup.py
+++ b/robot_ws/src/hello_world_robot/setup.py
@@ -4,7 +4,7 @@ package_name = 'hello_world_robot'
 
 setup(
     name=package_name,
-    version='2.0.0',
+    version='2.2.1',
     package_dir={'': 'src'},
     packages=find_packages(where='src'),
     data_files=[

--- a/simulation_ws/src/hello_world_simulation/package.xml
+++ b/simulation_ws/src/hello_world_simulation/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>hello_world_simulation</name>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <description>
     AWS RoboMaker simulation package with a TurtleBot3 in an empty Gazebo world.
   </description>


### PR DESCRIPTION
There was a security vulnerability in python. Bumping version in all packages given that the canonical python fix is patched.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
