### PR TITLE
Correct rviz model location

### DIFF
--- a/robot_ws/src/hello_world_robot/setup.py
+++ b/robot_ws/src/hello_world_robot/setup.py
@@ -34,7 +34,7 @@ setup(
         ('share/' + package_name + '/launch', ['launch/deploy_rotate.launch.py']),
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        ('rviz/', ['rviz/turtlebot3_model.rviz'])
+        ('share/rviz/', ['rviz/turtlebot3_model.rviz'])
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
*Description of changes:*

In the install folders, the `.rviz` file under the `hello_world_robot` package are under the `rviz` directory, when it should be under the `share/rviz` directory to be consistent with the `hello_world_simulation` package of the simulation workspace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
