### PR TITLE
Add log_workflow_status_to_cloudwatch in ros2foxy.yml

### DIFF
--- a/.github/workflows/ros2foxy.yml
+++ b/.github/workflows/ros2foxy.yml
@@ -87,3 +87,53 @@ jobs:
         USER_NAME: 'ros-contributions'
       if: ${{ github.event_name == 'schedule' && contains(steps.robot_ws_build.outcome, 'success') && contains(steps.simulation_ws_build.outcome, 'success') }} # Update app-manifest version number if the build was successful
   
+
+
+  log_workflow_status_to_cloudwatch:
+  runs-on: ubuntu-latest
+  container:
+    image: ubuntu:bionic
+  needs:
+  - build_and_bundle_ros2
+  if: ${{ always() && github.event_name != 'pull_request' }}
+  steps:
+  - name: Configure AWS Credentials
+    uses: aws-actions/configure-aws-credentials@v1.5.4
+    with:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ROS2 }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ROS2 }}
+      aws-region: ${{ secrets.AWS_REGION }}
+  - name: Log Robot Workspace Build Status
+    uses: ros-tooling/action-cloudwatch-metrics@0.0.4
+    with:
+      metric-dimensions: >-
+        [
+          { "Name": "github.event_name", "Value": "${{ github.event_name }}" },
+          { "Name": "github.ref", "Value": "refs/heads/ros2_foxy" },
+          { "Name": "github.repository", "Value": "${{ github.repository }}" }
+        ]
+      namespace: RobotWorkspaceBuild
+      metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'success') }}
+  - name: Log Simulation Workspace Build Status
+    uses: ros-tooling/action-cloudwatch-metrics@0.0.4
+    with:
+      metric-dimensions: >-
+        [
+          { "Name": "github.event_name", "Value": "${{ github.event_name }}" },
+          { "Name": "github.ref", "Value": "refs/heads/ros2_foxy" },
+          { "Name": "github.repository", "Value": "${{ github.repository }}" }
+        ]
+      namespace: SimulationWorkspaceBuild
+      metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'success') }}
+  - name: Log Bundle Upload Status
+    uses: ros-tooling/action-cloudwatch-metrics@0.0.4
+    with:
+      metric-dimensions: >-
+        [
+          { "Name": "github.event_name", "Value": "${{ github.event_name }}" },
+          { "Name": "github.ref", "Value": "refs/heads/ros2_foxy" },
+          { "Name": "github.repository", "Value": "${{ github.repository }}" }
+        ]
+      namespace: BundleUpload
+      metric-value: ${{ contains(needs.build_and_bundle_ros2.result, 'success') }}
+    if: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/ros2foxy.yml
+++ b/.github/workflows/ros2foxy.yml
@@ -92,9 +92,9 @@ jobs:
   log_workflow_status_to_cloudwatch:
   runs-on: ubuntu-latest
   container:
-    image: ubuntu:bionic
+    image: ubuntu:focal
   needs:
-  - build_and_bundle_ros2
+  - build_and_bundle_ros2_foxy
   if: ${{ always() && github.event_name != 'pull_request' }}
   steps:
   - name: Configure AWS Credentials
@@ -113,7 +113,7 @@ jobs:
           { "Name": "github.repository", "Value": "${{ github.repository }}" }
         ]
       namespace: RobotWorkspaceBuild
-      metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.robot_ws_build_result, 'success') }}
+      metric-value: ${{ contains(needs.build_and_bundle_ros2_foxy.outputs.robot_ws_build_result, 'success') }}
   - name: Log Simulation Workspace Build Status
     uses: ros-tooling/action-cloudwatch-metrics@0.0.4
     with:
@@ -124,7 +124,7 @@ jobs:
           { "Name": "github.repository", "Value": "${{ github.repository }}" }
         ]
       namespace: SimulationWorkspaceBuild
-      metric-value: ${{ contains(needs.build_and_bundle_ros2.outputs.simulation_ws_build_result, 'success') }}
+      metric-value: ${{ contains(needs.build_and_bundle_ros2_foxy.outputs.simulation_ws_build_result, 'success') }}
   - name: Log Bundle Upload Status
     uses: ros-tooling/action-cloudwatch-metrics@0.0.4
     with:
@@ -135,5 +135,5 @@ jobs:
           { "Name": "github.repository", "Value": "${{ github.repository }}" }
         ]
       namespace: BundleUpload
-      metric-value: ${{ contains(needs.build_and_bundle_ros2.result, 'success') }}
+      metric-value: ${{ contains(needs.build_and_bundle_ros2_foxy.result, 'success') }}
     if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
*Issue #, if available:*
Now that foxy canaries are in place, we need to add the log_workflow_status_to_cloudwatch to the github action workflow

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
