### PR TITLE
Update ROS2 branch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ _RoboMaker sample applications include third-party software licensed under open-
 
 ## Requirements
 
-- [ROS2 Dashing](https://index.ros.org//doc/ros2/Installation/Dashing) or [ROS2 Foxy](https://docs.ros.org/en/foxy/Installation.html) - Other versions may work, however they have not been tested
+- [ROS2 Foxy](https://docs.ros.org/en/foxy/Installation.html) - Other versions may work, however they have not been tested
+- [vcstool](https://github.com/dirk-thomas/vcstool#how-to-install-vcstool) - Used to pull in sample app dependencies that are only available from source, not from apt or pip.
+- [rosdep](http://wiki.ros.org/rosdep#Installing_rosdep) - rosdep is a command-line tool for installing system dependencies of ROS packages.
 - [Colcon](https://colcon.readthedocs.io/en/released/user/installation.html) - Used for building and bundling the application.
 
 ## Build


### PR DESCRIPTION
- Remove ROS2 Dashing
- Add missing installation instruction for vcstool and rosdep