### PR TITLE
Remove chown step (ROS2)

### DIFF
--- a/.github/workflows/ros2.yml
+++ b/.github/workflows/ros2.yml
@@ -30,10 +30,6 @@ jobs:
       uses: actions/checkout@v1
       with:
         ref: 'ros2'
-    - name: Setup Permissions
-      run: |
-        # TODO(ros-tooling/setup-ros-docker#7): calling chown is necessary for now
-        sudo chown -R rosbuild:rosbuild "$HOME" .
     - name: Scan using git-secrets
       uses: aws-robotics/aws-robomaker-github-actions/git-secrets-scan-action@3.0.3
     - id: robot_ws_build


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove chown step (ROS2) because it's not required anymore (see ros-tooling/setup-ros-docker/issues/7)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
