### PR TITLE
Add xacro as a dependency

### DIFF
--- a/robot_ws/src/hello_world_robot/package.xml
+++ b/robot_ws/src/hello_world_robot/package.xml
@@ -22,6 +22,7 @@
   <depend>turtlebot3_msgs</depend>
   <depend>turtlebot3_description</depend>
   <depend>turtlebot3_description_reduced_mesh</depend>
+  <depend>xacro</depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>


### PR DESCRIPTION
Add `xacro` as a dependency in package.xml. It's used in the robot workspace launch files (for example, [rotate.launch](https://github.com/aws-robotics/aws-robomaker-sample-application-helloworld/blob/ros1/robot_ws/src/hello_world_robot/launch/rotate.launch#L16)).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
