### PR TITLE
Update Dockerfile regarding missing turtlebot3 issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ WORKDIR $IMAGE_WS_DIR
 COPY --chown=$USERNAME:$USERNAME $LOCAL_WS_DIR/src $IMAGE_WS_DIR/src
 
 RUN sudo apt update && \
-    rosdep update && \
+    rosdep update --include-eol-distros && \
     rosdep fix-permissions
 
 # Note: This will install all dependencies.


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Update Dockerfile by adding "--include-eol-distros" to "rosdep update", regarding missing turtlebot3 issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
